### PR TITLE
fix: several meanings (translation) were concatenated without commas …

### DIFF
--- a/src/molecules/BackSide/index.jsx
+++ b/src/molecules/BackSide/index.jsx
@@ -14,7 +14,7 @@ const BackSide = () => {
 			<Stack justifyContent="center" alignItems="center" spacing={2}>
 				<CardContent>
 					<Typography align="center" variant="h5" color="text.secondary">
-						{currentCard.meaning}
+						{currentCard.meaning.join(", ")}
 					</Typography>
 				</CardContent>
 				<CardHeaderFlipped />

--- a/src/molecules/FrontSide/index.jsx
+++ b/src/molecules/FrontSide/index.jsx
@@ -70,7 +70,7 @@ const FrontSide = () => {
 					)}
 					{learnMode && showTranslation && (
 						<Typography align="center" variant="body2" color="text.secondary">
-							{currentCard.meaning}
+							{currentCard.meaning.join(", ")}
 						</Typography>
 					)}
 					<button


### PR DESCRIPTION
…or spaces

## Motivation
<!-- List motivation and changes here -->
the words on some translation fields are concatenated without a comma or space.

AC:

 fix textfield, so that it correctly displays multiple entries in the translation array


## Issues closed
<!-- List closed issues here -->
closes #42 
