### PR TITLE
fix: pressing back button when the queue was empty would crash the app

### DIFF
--- a/src/ions/store/store.jsx
+++ b/src/ions/store/store.jsx
@@ -58,7 +58,12 @@ const useStore = create(
 			},
 			setLessonData: lessonData => {
 				const lessonLength = lessonData.length;
-				set(() => ({ lessonData, filteredData: lessonData, lessonLength }));
+				set(() => ({
+					lessonData,
+					filteredData: lessonData,
+					lessonLength,
+					recentCards: [],
+				}));
 			},
 
 			currentCard: {

--- a/src/molecules/about-modal/index.jsx
+++ b/src/molecules/about-modal/index.jsx
@@ -64,7 +64,7 @@ const AboutModal = () => {
 						<Typography id="modal-modal-description" sx={{ mt: 2 }}>
 							Japanese Vocabulary Learning App
 							<br />
-							<small>Version 1.1.0</small>
+							<small>Version 1.1.1</small>
 							<br />
 							<br />
 							<StyledLogoDiv>

--- a/src/molecules/card-footer/index.jsx
+++ b/src/molecules/card-footer/index.jsx
@@ -43,10 +43,13 @@ const CardFooter = () => {
 		const myRecentCards = [...recentCards];
 
 		await setPrevCard();
-
-		const lastCardNumber = myRecentCards.pop();
-		const previousCard = filteredData.find(element => element.vocabularyNo === lastCardNumber);
-		setCurrentCard(previousCard);
+		if (myRecentCards.length > 0) {
+			const lastCardNumber = myRecentCards.pop();
+			const previousCard = filteredData.find(
+				element => element.vocabularyNo === lastCardNumber
+			);
+			setCurrentCard(previousCard);
+		}
 	};
 	return (
 		<CardActions>
@@ -74,6 +77,7 @@ const CardFooter = () => {
 				{!legacyMode && (
 					<IconButton
 						aria-label="back"
+						disabled={!recentCards.length > 0}
 						variant="outlined"
 						size="large"
 						color="primary"


### PR DESCRIPTION
## Motivation
fixed bug that an empty undo queue would crash the app when the back button was pressed. Now the button is being disabled when the queue has 0 length.

## Issues closed
closes #51 
